### PR TITLE
Drop deprecated libfaac support.

### DIFF
--- a/unofficial/ffmpeg/ffmpeg.SlackBuild
+++ b/unofficial/ffmpeg/ffmpeg.SlackBuild
@@ -120,8 +120,6 @@ libsnappy=""  ; [ "${SNAPPY:-no}" != "no" ]       && libsnappy="--enable-libsnap
 
 opencore_amr="" ; [ "${OPENCORE:-no}" != "no" ] && \
   opencore_amr="--enable-libopencore-amrnb --enable-libopencore-amrwb"
-libfaac=""      ; [ "${FAAC:-no}" != "no" ]     && \
-  { libfaac="--enable-libfaac" ; non_free="--enable-nonfree" ; }
 fdk=""        ; [ "${FDK_AAC:-no}" != "no" ]      && \
   { fdk="--enable-libfdk-aac"; non_free="--enable-nonfree" ; }
 ssl=""      ; [ "${OPENSSL:-no}" != "no" ]     && \


### PR DESCRIPTION
getting: Unknown option "--enable-libfaad".
reason: libfaad support was removed from FFmpeg in 2010 due to the maturation of the native FFmpeg AAC decoder.
reference: https://ubuntuforums.org/showthread.php?t=2328054